### PR TITLE
Fixed missing model

### DIFF
--- a/.github/workflows/release_on_push.yml
+++ b/.github/workflows/release_on_push.yml
@@ -26,6 +26,18 @@ jobs:
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+      
+      - name: Download MiniLM ONNX model
+        run: |
+          mkdir -p mabl/src/main/assets
+          if [ ! -f mabl/src/main/assets/minilm-l6-v2-qint8-arm64.onnx ]; then
+            curl -L -o mabl/src/main/assets/minilm-l6-v2-qint8-arm64.onnx "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_qint8_arm64.onnx?download=true"
+          fi
+
+      - name: Verify ONNX model present
+        run: |
+          test -f mabl/src/main/assets/minilm-l6-v2-qint8-arm64.onnx
+          ls -lh mabl/src/main/assets
 
       - name: Build Release APKs
         run: ./gradlew assembleRelease :mabl:assembleAipinRelease :mabl:assembleAipinSimulatorRelease :mabl:assembleAndroidRelease

--- a/.github/workflows/release_on_push.yml
+++ b/.github/workflows/release_on_push.yml
@@ -30,14 +30,7 @@ jobs:
       - name: Download MiniLM ONNX model
         run: |
           mkdir -p mabl/src/main/assets
-          if [ ! -f mabl/src/main/assets/minilm-l6-v2-qint8-arm64.onnx ]; then
-            curl -L -o mabl/src/main/assets/minilm-l6-v2-qint8-arm64.onnx "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_qint8_arm64.onnx?download=true"
-          fi
-
-      - name: Verify ONNX model present
-        run: |
-          test -f mabl/src/main/assets/minilm-l6-v2-qint8-arm64.onnx
-          ls -lh mabl/src/main/assets
+          curl -L -f -o mabl/src/main/assets/minilm-l6-v2-qint8-arm64.onnx "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_qint8_arm64.onnx?download=true"
 
       - name: Build Release APKs
         run: ./gradlew assembleRelease :mabl:assembleAipinRelease :mabl:assembleAipinSimulatorRelease :mabl:assembleAndroidRelease


### PR DESCRIPTION
I added two steps to /.github/workflows/release_on_push.yml before the Gradle build:
- Download minilm-l6-v2-qint8-arm64.onnx into mabl/src/main/assets
- Verify the file exists
These mirror the logic in build.sh, which already downloads from Hugging Face if missing.